### PR TITLE
Add Events page with live Luma calendar embed

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -4,6 +4,11 @@
   weight = 10
 
 [[main]]
+  name = "Events"
+  pageRef = "/events/"
+  weight = 15
+
+[[main]]
   name = "Blog"
   pageRef = "/blog/"
   weight = 20

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -210,7 +210,8 @@
         "www.youtube.com",
         "app.netlify.com",
         "www.canva.com",
-        "drive.google.com"
+        "drive.google.com",
+        "luma.com"
     ]
     img-src = [
         "data:",

--- a/config/_default/server.toml
+++ b/config/_default/server.toml
@@ -11,7 +11,7 @@
         default-src 'none'; \
         font-src 'self' fonts.gstatic.com; \
         form-action 'self'; \
-        frame-src 'self' player.cloudinary.com www.youtube-nocookie.com www.youtube.com player.vimeo.com app.netlify.com www.canva.com drive.google.com; \
+        frame-src 'self' player.cloudinary.com www.youtube-nocookie.com www.youtube.com player.vimeo.com app.netlify.com www.canva.com drive.google.com luma.com; \
         img-src 'self' cdn-cookieyes.com *.google-analytics.com *.googletagmanager.com *.netlify.com data: *.imgix.net *.imagekit.io *.cloudinary.com i.ytimg.com tile.openstreetmap.org i.vimeocdn.com; \
         manifest-src 'self'; \
         media-src 'self'; \

--- a/content/_index.md
+++ b/content/_index.md
@@ -22,3 +22,21 @@ actions:
     title: "Blog"
     weight: 3
 ---
+
+<div class="text-center my-5">
+  <h2 id="upcoming-events">Upcoming Events</h2>
+  <p>Join us at our next meetup! Browse what's coming up and RSVP through our Luma calendar.</p>
+  <iframe
+    src="https://luma.com/embed/calendar/cal-EefnU0O5BifyHgg/events"
+    width="100%"
+    height="450"
+    frameborder="0"
+    style="border: 1px solid #bfcbda88; border-radius: 8px; max-width: 800px; display: block; margin: 0 auto;"
+    allowfullscreen=""
+    aria-hidden="false"
+    tabindex="0"
+  ></iframe>
+  <div class="mt-4">
+    <a class="btn btn-primary" href="/events/" role="button">See all events</a>
+  </div>
+</div>

--- a/content/events.md
+++ b/content/events.md
@@ -1,0 +1,30 @@
+---
+author: PyLadies Vancouver
+title: Events
+description: Upcoming PyLadies Vancouver meetups and events — RSVP through our Luma calendar.
+date: 2026-06-13
+updated: 2026-06-13
+showComments: false
+---
+
+Here's what's coming up at PyLadies Vancouver. RSVP to any event directly through our Luma
+calendar below — and [subscribe to our Luma calendar](https://api.luma.com/ics/get?entity=calendar&id=cal-EefnU0O5BifyHgg)
+to get new events in your own calendar app automatically.
+
+<iframe
+  src="https://luma.com/embed/calendar/cal-EefnU0O5BifyHgg/events"
+  width="100%"
+  height="600"
+  frameborder="0"
+  style="border: 1px solid #bfcbda88; border-radius: 8px; max-width: 800px;"
+  allowfullscreen=""
+  aria-hidden="false"
+  tabindex="0"
+></iframe>
+
+Not seeing the calendar? View our events directly on
+[luma.com/pyladiesvancouver](https://luma.com/pyladiesvancouver).
+
+{{< button color="secondary" tooltip="View our events on Luma" href="https://luma.com/pyladiesvancouver" >}}
+    View all events on Luma
+{{< /button >}}


### PR DESCRIPTION
## Summary

Adds a dedicated **Events** page and surfaces upcoming events on the landing page, using a live embed of our [Luma calendar](https://luma.com/pyladiesvancouver) so events and RSVPs stay in sync automatically — no per-event site changes needed.

- **New `/events/` page** embedding the Luma calendar (responsive iframe) with inline RSVP, a fallback link, and a calendar-subscribe (ICS) link
- **"Events" added to the top nav** (About · Events · Blog)
- **Upcoming-events snippet on the landing page** — a compact Luma embed in an "Upcoming Events" section above the blog feed, with a "See all events" button to `/events/`
- **CSP** updated to allow `luma.com` frames, in both the production `netlify.toml` (via `[modules.hinode.csp]` in `params.toml`) and the dev `server.toml`

## Test plan
- [x] Clean build with Hugo 0.141.0 (theme-pinned version)
- [x] `/events/` page renders the embed; nav link present
- [x] Landing page shows the embed snippet, ordered Upcoming Events → Blog → Get Involved
- [x] Production CSP `frame-src` includes `luma.com`
- [ ] **Manual check:** run `hugo server`, open `/events/` and `/`, confirm the Luma calendar loads with no CSP console errors (if Luma redirects `luma.com` → `lu.ma`, add `lu.ma` to the same two `frame-src` lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)