### PR TITLE
Point general donate links to the PyLadies Vancouver fund

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ actions:
     title: "About us"
     weight: 1
   donate:
-    url: "https://psfmember.org/civicrm/contribute/transact/?reset=1&id=53"
+    url: "https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60"
     title: "Donate"
     weight: 4
   events:

--- a/content/about.md
+++ b/content/about.md
@@ -25,8 +25,8 @@ PyLadies Vancouver reside and share knowledge on the unceded territories of the 
 Səl̓ílwətaʔ/Selilwitulh Nations. We encourage participation from members from Indigenous communities across Canada.
 
 
-{{< button href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=53" >}}
-    Donate to PyLadiesCon
+{{< button href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60" >}}
+    Donate to PyLadies Vancouver
 {{< /button >}}
 
 

--- a/content/get_involved/donate.md
+++ b/content/get_involved/donate.md
@@ -7,9 +7,9 @@ weight: 2
 colormode: true
 ---
 
-Support the PyLadies community by donating to PyLadiesCon, the global PyLadies
-online conference.
+Support PyLadies Vancouver to help cover the costs of running our meetups, workshops,
+and community events.
 
-{{< button href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=53" >}}
-    Donate to PyLadiesCon
+{{< button href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60" >}}
+    Donate to PyLadies Vancouver
 {{< /button >}}


### PR DESCRIPTION
## Summary

The site's general "support us" donate links pointed to the PyLadiesCon fund (`id=53`). This switches them to the **PyLadies Vancouver** fund (`id=60`) and relabels them, so donating from the site supports the local chapter directly.

Changed:
- **Homepage hero "Donate" button** → PyLadies Vancouver fund
- **About page** button → "Donate to PyLadies Vancouver" (`id=60`)
- **Get Involved donate card** → relabeled, with updated copy about supporting our meetups, workshops, and community events

Left unchanged:
- The **blog posts'** PyLadiesCon-specific donation links (`id=53`) — those intentionally point to PyLadiesCon.

## Test plan
- [x] Clean build with Hugo 0.141.0 (theme-pinned version)
- [x] Homepage hero + Get Involved donate card and About page now use `id=60`
- [x] Blog posts still use `id=53` (PyLadiesCon)
- [x] No `id=53` leaked onto homepage/About

🤖 Generated with [Claude Code](https://claude.com/claude-code)