### PR TITLE
Add multi-page Handbook section (participation & organizing guides)

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -13,6 +13,11 @@
   pageRef = "/blog/"
   weight = 20
 
+[[main]]
+  name = "Handbook"
+  pageRef = "/handbook/"
+  weight = 30
+
 #
 #[[main]]
 #  name = "Projects"
@@ -41,6 +46,12 @@
   pre = "fab linkedin"
   url = "https://linkedin.com/company/pyladies-vancouver"
   weight = 10
+
+[[social]]
+  name = "Instagram"
+  pre = "fa-brands fa-instagram"
+  url = "https://www.instagram.com/pyladiesyvr"
+  weight = 15
 
 [[social]]
   name = "GitHub"

--- a/content/about.md
+++ b/content/about.md
@@ -24,6 +24,13 @@ education, conferences, events and social gatherings.
 PyLadies Vancouver reside and share knowledge on the unceded territories of the xʷməθkwəy̓əm, Skwxwú7mesh, Stó:lō an
 Səl̓ílwətaʔ/Selilwitulh Nations. We encourage participation from members from Indigenous communities across Canada.
 
+Want to get involved or stay in touch between meetups? Join the conversation in the
+**#city-vancouver** channel on the PyLadies Slack.
+
+{{< button href="https://slackin.pyladies.com" >}}
+    Join the PyLadies Slack
+{{< /button >}}
+
 
 {{< button href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60" >}}
     Donate to PyLadies Vancouver

--- a/content/get_involved/donate.md
+++ b/content/get_involved/donate.md
@@ -10,6 +10,6 @@ colormode: true
 Support PyLadies Vancouver to help cover the costs of running our meetups, workshops,
 and community events.
 
-{{< button href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60" >}}
-    Donate to PyLadies Vancouver
+{{< button href="/handbook/ways-to-participate/donate/" >}}
+    Donate & sponsor
 {{< /button >}}

--- a/content/get_involved/host.md
+++ b/content/get_involved/host.md
@@ -12,6 +12,6 @@ If you have an event space in Vancouver, and can host our next meetup, we'd love
 A space for 20-30 people with projector would be great. We're also looking for a space that is accessible by public transit.
 
 
-{{< button href="mailto:vancouver@pyladies.com" >}}
-    Get in touch
+{{< button href="/handbook/ways-to-participate/host/" >}}
+    Host a venue
 {{< /button >}}

--- a/content/get_involved/speak.md
+++ b/content/get_involved/speak.md
@@ -10,6 +10,6 @@ colormode: true
 We're always looking for speakers at our meetup! No experience necessary. Whether you're speaking for the first time, or a
 seasoned presenter, we welcome you in our community.
 
-{{< button href="https://sessionize.com/pyladies-vancouver-meetup/" >}}
-    Submit your talk idea.
+{{< button href="/handbook/ways-to-participate/speak/" >}}
+    Speak at our meetup
 {{< /button >}}

--- a/content/handbook/_index.md
+++ b/content/handbook/_index.md
@@ -1,0 +1,64 @@
+---
+author: PyLadies Vancouver
+title: Handbook
+description: How PyLadies Vancouver works — guides for speaking, hosting, donating, and organizing our meetups.
+date: 2026-06-21
+nested: true
+weight: 25
+toc: true
+cascade:
+  metadata: none
+---
+
+Welcome to the PyLadies Vancouver Handbook! This is an open guide to how our community
+works — whether you'd like to **speak** at a meetup, **host** a venue, **donate**, or
+**help organize**, you'll find what you need here.
+
+We're publishing this in the open for two reasons: so anyone helping out has a clear,
+repeatable guide to follow, and so our community can see how much goes into each event.
+
+## Who this is for
+
+- **Speakers** — see [Speak at our meetup](/handbook/ways-to-participate/speak/)
+- **Venue hosts** — see [Host a venue](/handbook/ways-to-participate/host/)
+- **Donors & sponsors** — see [Donate and sponsor](/handbook/ways-to-participate/donate/)
+- **Organizers & volunteers** — see [Organizing a meetup](/handbook/organizing-a-meetup/)
+
+## How this handbook is organized
+
+- **Ways to participate** — guides for speaking, hosting, donating, and helping organize
+- **Organizing a meetup** — the behind-the-scenes steps we follow to run an event, plus
+  how this website is built and edited
+- **Templates** — reusable starting points, like our event description template
+
+## Anyone can help
+
+You don't need to be a designated "organizer" to pitch in. We coordinate in the
+**#city-vancouver** channel in the PyLadies Slack — come say hi, tell us what you'd like
+to help with, and we'll get you started. You can also reach us at **vancouver at pyladies
+dot com**.
+
+{{< button href="https://slackin.pyladies.com" >}}
+    Join the PyLadies Slack
+{{< /button >}}
+
+## Stay up to date
+
+Keep up with what we're doing:
+
+- **Subscribe to our [Luma calendar](https://api.luma.com/ics/get?entity=calendar&id=cal-EefnU0O5BifyHgg)**
+  to get upcoming events in your own calendar app
+- **Subscribe to our <a href="/index.xml">RSS feed</a>** for new blog posts
+- **Follow us on social media** — LinkedIn, Instagram, Mastodon, and Bluesky (linked below)
+- **Follow our hashtag** — **#pyladiesvancouver**
+
+## Get in touch
+
+- **Slack** — the **#city-vancouver** channel on the [PyLadies Slack](https://slackin.pyladies.com)
+- **Email** — **vancouver at pyladies dot com**
+
+You can also find us on
+[LinkedIn](https://linkedin.com/company/pyladies-vancouver),
+[Instagram](https://www.instagram.com/pyladiesyvr),
+[Mastodon](https://fosstodon.org/@pyladies_vancouver), and
+[Bluesky](https://bsky.app/profile/pyladiesvancouver.bsky.social).

--- a/content/handbook/organizing-a-meetup/_index.md
+++ b/content/handbook/organizing-a-meetup/_index.md
@@ -1,0 +1,24 @@
+---
+author: PyLadies Vancouver
+title: Organizing a meetup
+description: The behind-the-scenes steps PyLadies Vancouver follows to run a meetup.
+weight: 20
+---
+
+This section walks through how a meetup comes together, from finding a date to publishing
+the recap. The stages overlap and the timeline flexes, but this is the general order.
+
+> **Always CC vancouver@pyladies.com** on any communication with venues, vendors, and
+> speakers. It keeps the whole organizing team in the loop and means nothing depends on a
+> single person's inbox — as long as that address is copied, you're good to go.
+
+1. [Where things live](/handbook/organizing-a-meetup/where-things-live/)
+2. [Pick a date and venue](/handbook/organizing-a-meetup/date-and-venue/)
+3. [Speakers and call for proposals](/handbook/organizing-a-meetup/speakers-and-cfp/)
+4. [Create the Luma event](/handbook/organizing-a-meetup/create-luma-event/)
+5. [Announce the event](/handbook/organizing-a-meetup/announce/)
+6. [On the day](/handbook/organizing-a-meetup/on-the-day/)
+7. [Wrap-up and recap](/handbook/organizing-a-meetup/wrap-up-and-recap/)
+
+Plus: [Updating the website](/handbook/organizing-a-meetup/updating-the-website/) — how the
+site is built and edited.

--- a/content/handbook/organizing-a-meetup/announce.md
+++ b/content/handbook/organizing-a-meetup/announce.md
@@ -1,0 +1,21 @@
+---
+author: PyLadies Vancouver
+title: Announce the event
+description: Where and how PyLadies Vancouver announces an event.
+weight: 50
+---
+
+Once the Luma event is live, announce it on **Meetup** and across **all of our social media
+channels**, pointing everyone to Luma to RSVP.
+
+Post the event to:
+
+- [Meetup](https://www.meetup.com/pyladies-vancouver/)
+- [LinkedIn](https://linkedin.com/company/pyladies-vancouver)
+- [Mastodon](https://fosstodon.org/@pyladies_vancouver)
+- [Instagram](https://www.instagram.com/pyladiesyvr)
+- [Bluesky](https://bsky.app/profile/pyladiesvancouver.bsky.social)
+
+People can also
+[subscribe to our Luma calendar](https://api.luma.com/ics/get?entity=calendar&id=cal-EefnU0O5BifyHgg)
+to get upcoming events in their own calendar app automatically.

--- a/content/handbook/organizing-a-meetup/create-luma-event.md
+++ b/content/handbook/organizing-a-meetup/create-luma-event.md
@@ -1,0 +1,24 @@
+---
+author: PyLadies Vancouver
+title: Create the Luma event
+description: Publishing a PyLadies Vancouver event on Luma.
+weight: 40
+toc: true
+---
+
+We publish each event on **Luma**, which handles RSVPs, reminders, and a subscribable
+calendar. Build the description from the confirmed Sessionize talk and speaker details.
+
+Use the [Luma event template](/handbook/templates/luma-event-template/) as your starting
+point.
+
+## Tips
+
+- **Luma's API requires a paid Luma Plus plan**, so on the free tier we create events
+  through the web editor. Luma supports Markdown, so the template pastes in directly.
+- Luma supports only two heading levels (`#` and `##`) — keep the description to those.
+- Add the speaker photo(s) from Sessionize as the event/cover image.
+- Double-check the date, start/end time (leave room for cleanup), location, and capacity.
+
+Once published, the event automatically appears on our
+[Events page](/events/) and homepage, which embed the Luma calendar.

--- a/content/handbook/organizing-a-meetup/date-and-venue.md
+++ b/content/handbook/organizing-a-meetup/date-and-venue.md
@@ -1,0 +1,31 @@
+---
+author: PyLadies Vancouver
+title: Pick a date and venue
+description: Confirming a date and securing a venue host for a PyLadies Vancouver meetup.
+weight: 20
+toc: true
+---
+
+We aim to confirm a date and a venue host first, since the venue is usually the longest
+lead time.
+
+## What we need from a venue
+
+The bare minimum we need from a venue host is **a space that fits our group and a
+projector/AV setup** for the talks. The PyLadies organizer still handles all the
+coordination. See the full [Host a venue](/handbook/ways-to-participate/host/) guide for
+what we ask of hosts.
+
+Food (often pizza) is **optional** — appreciated but not required, and it can be covered by
+a separate sponsor who isn't the venue host.
+
+## Hosting agreements
+
+Most venues ask us to sign an **event hosting agreement** covering booking lead time,
+setup and cleanup responsibilities, access procedures, and a cancellation policy. Read it
+carefully — agreements often require a host contact or volunteer to be confirmed weeks in
+advance, and the booking can be cancelled if that isn't arranged in time.
+
+> **Venue access details** (door codes, alarm procedures, day-of contacts) are sensitive
+> and are kept in a private organizer document, shared only with the team running that
+> specific event — never published on this site.

--- a/content/handbook/organizing-a-meetup/on-the-day.md
+++ b/content/handbook/organizing-a-meetup/on-the-day.md
@@ -1,0 +1,18 @@
+---
+author: PyLadies Vancouver
+title: On the day
+description: Running a PyLadies Vancouver meetup on the day of the event.
+weight: 60
+---
+
+On the day, the organizing team runs the show:
+
+- **Doors & check-in** — welcome attendees as they arrive
+- **PyLadies intro & community updates** — kick things off and share announcements
+- **Introduce the speaker(s)** and keep the program on time
+- **Q&A** after each talk
+- **Fundraising** — tote bag sales, conference swag, and pointing people to donate
+
+Follow the venue's access and conduct rules throughout, and make sure everyone is aware of
+the [PyLadies Code of Conduct](https://www.pyladies.com/CodeOfConduct/). Day-of venue access
+details live in the private organizer document for that event.

--- a/content/handbook/organizing-a-meetup/speakers-and-cfp.md
+++ b/content/handbook/organizing-a-meetup/speakers-and-cfp.md
@@ -1,0 +1,30 @@
+---
+author: PyLadies Vancouver
+title: Speakers and call for proposals
+description: Collecting talk proposals and confirming speakers through Sessionize.
+weight: 30
+toc: true
+---
+
+We collect talk submissions through **Sessionize**. Our call for proposals lives at
+[sessionize.com/pyladies-vancouver-meetup](https://sessionize.com/pyladies-vancouver-meetup/).
+
+## Talk formats we accept
+
+- **Lightning talks** — 5 minutes
+- **Standard talks** — 15–30 minutes
+- **Workshops** — up to 2 hours
+
+No experience is necessary to speak — we welcome first-time and seasoned speakers alike.
+Point prospective speakers to the [Speak at our meetup](/handbook/ways-to-participate/speak/)
+guide.
+
+## Working with Sessionize
+
+Once talks are accepted and speakers confirm, Sessionize holds the session titles,
+abstracts, and speaker bios. Organizers can pull this data from the Sessionize API to fill
+in the event page and recap, instead of retyping it — there are read-only API endpoints for
+sessions and speakers.
+
+Confirm each speaker's talk title, abstract, and bio before you publish the event, and keep
+**vancouver@pyladies.com** CC'd on speaker communications.

--- a/content/handbook/organizing-a-meetup/updating-the-website.md
+++ b/content/handbook/organizing-a-meetup/updating-the-website.md
@@ -1,0 +1,28 @@
+---
+author: PyLadies Vancouver
+title: Updating the website
+description: How the PyLadies Vancouver website is built and edited.
+weight: 80
+toc: true
+---
+
+The site is a [Hugo](https://gohugo.io/) project using the Hinode theme, in
+[our GitHub repo](https://github.com/pyladies-vancouver/pyladies-vancouver.github.io).
+Changes go through a pull request and deploy automatically via Netlify once merged.
+
+## Blog posts
+
+Blog posts live in `content/blog/` as Markdown files with front matter (title, author,
+date, description, tags, thumbnail). Event photos go in `assets/img/`.
+
+## Building locally
+
+Build locally with the Hugo version the theme is pinned to — the newer Homebrew Hugo can
+break the Hinode theme. Run the local dev server, check your changes, then open a pull
+request.
+
+## Events
+
+Upcoming events are pulled live from our Luma calendar, which is embedded on the
+[Events page](/events/) and the homepage. Once an event is published on Luma it appears on
+the site automatically — no code change needed per event.

--- a/content/handbook/organizing-a-meetup/where-things-live.md
+++ b/content/handbook/organizing-a-meetup/where-things-live.md
@@ -1,0 +1,25 @@
+---
+author: PyLadies Vancouver
+title: Where things live
+description: The tools and platforms PyLadies Vancouver uses to run events.
+weight: 10
+---
+
+Here's where everything lives and what we use it for.
+
+| What | Where | Used for |
+| --- | --- | --- |
+| **Website** | [github.com/pyladies-vancouver/pyladies-vancouver.github.io](https://github.com/pyladies-vancouver/pyladies-vancouver.github.io) | Our site, built with [Hugo](https://gohugo.io/) and the [Hinode](https://gethinode.com/) theme, deployed via Netlify |
+| **Luma** | [luma.com/pyladiesvancouver](https://luma.com/pyladiesvancouver) | RSVPs and event pages (our primary platform) |
+| **Meetup** | [meetup.com/pyladies-vancouver](https://www.meetup.com/pyladies-vancouver/) | Announcing events; we point people to Luma to RSVP |
+| **Sessionize** | [sessionize.com/pyladies-vancouver-meetup](https://sessionize.com/pyladies-vancouver-meetup/) | Call for proposals and managing speaker info |
+| **PyLadies Vancouver donations** | [Donate](https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60) | Supporting our local chapter |
+| **PyLadiesCon donations** | [Donate](https://psfmember.org/civicrm/contribute/transact/?reset=1&id=53) | Supporting the global PyLadies community |
+| **Email** | vancouver at pyladies dot com | Getting in touch with the organizers |
+| **Slack** | [#city-vancouver via slackin.pyladies.com](https://slackin.pyladies.com) | Where organizers and volunteers coordinate |
+
+We also share updates on
+[LinkedIn](https://linkedin.com/company/pyladies-vancouver),
+[Instagram](https://www.instagram.com/pyladiesyvr),
+[Mastodon](https://fosstodon.org/@pyladies_vancouver), and
+[Bluesky](https://bsky.app/profile/pyladiesvancouver.bsky.social).

--- a/content/handbook/organizing-a-meetup/wrap-up-and-recap.md
+++ b/content/handbook/organizing-a-meetup/wrap-up-and-recap.md
@@ -1,0 +1,27 @@
+---
+author: PyLadies Vancouver
+title: Wrap-up and recap
+description: Resetting the venue after a meetup and publishing a recap.
+weight: 70
+toc: true
+---
+
+## Wrap up the venue
+
+After the event, reset the space to how we found it:
+
+- Return furniture to its original arrangement
+- Clean up tables, dishes, and any food
+- Sort garbage, recycling, and compost per the venue's rules
+- Follow the venue's closing/security checklist exactly
+
+Following the wrap-up steps carefully is what keeps us welcome to come back. The specific
+closing steps for each venue are in that event's private organizer document.
+
+## Publish a recap
+
+Write up a recap as a [blog post](/blog/) — a thank-you to the speaker and venue, photos
+from the event, and a note about what's coming next. This is also a good place to list
+other Python and open source events worth knowing about. See
+[Updating the website](/handbook/organizing-a-meetup/updating-the-website/) for how to add
+a post.

--- a/content/handbook/templates/_index.md
+++ b/content/handbook/templates/_index.md
@@ -1,0 +1,11 @@
+---
+author: PyLadies Vancouver
+title: Templates
+description: Reusable templates for PyLadies Vancouver events.
+weight: 30
+---
+
+Reusable starting points to save time when organizing:
+
+- **[Luma event template](/handbook/templates/luma-event-template/)** — a Markdown template
+  for our event description pages

--- a/content/handbook/templates/luma-event-template.md
+++ b/content/handbook/templates/luma-event-template.md
@@ -1,0 +1,62 @@
+---
+author: PyLadies Vancouver
+title: Luma event template
+description: A reusable Markdown template for PyLadies Vancouver event descriptions on Luma.
+weight: 10
+toc: true
+---
+
+Paste this into the Luma event description (it's Markdown) and fill in the talk and speaker
+details from Sessionize. Adjust the agenda times to match the program. Luma supports only
+two heading levels (`#` and `##`).
+
+````markdown
+Join PyLadies Vancouver for our meetup at **[VENUE]**!
+
+# [TALK TITLE] — [SPEAKER NAME]
+
+[TALK ABSTRACT]
+
+**About [SPEAKER NAME]**
+
+[SPEAKER BIO]
+
+[Speaker links]
+
+## Agenda
+
+- **6:00 PM** — Doors open, food & mingling
+- **6:15 PM** — PyLadies intro & community updates
+- **6:20 PM** — [TALK TITLE] ([SPEAKER NAME])
+- **7:00 PM** — Fundraiser, swag & wrap-up
+- **7:45 PM** — Event ends
+
+## Support PyLadies Vancouver
+
+Help us keep our meetups running — [donate to PyLadies Vancouver](https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60)
+to support the costs of organizing community events like this one.
+
+We'll also be selling PyLadies tote bags in support of **PyLadiesCon**, and we'll have
+conference swag to share!
+
+## Thank you to our venue host: [VENUE]
+
+Thank you to [VENUE] for providing the space for this meetup!
+
+## Getting in
+
+[Arrival and building-access instructions for attendees — which floor, how to be buzzed
+in, parking and transit notes.]
+
+## House rules
+
+Please stay within the designated event areas. Photos of our event and attendees (with
+their consent) are welcome. All attendees must follow the
+[PyLadies Code of Conduct](https://www.pyladies.com/CodeOfConduct/).
+````
+
+## Other fields to set on Luma
+
+- **Title**, **date/time** (leave room for cleanup before the venue's hard stop)
+- **Location** and **capacity**
+- **Cover image** — the speaker photo from Sessionize

--- a/content/handbook/ways-to-participate/_index.md
+++ b/content/handbook/ways-to-participate/_index.md
@@ -1,0 +1,20 @@
+---
+author: PyLadies Vancouver
+title: Ways to participate
+description: How to get involved with PyLadies Vancouver — speak, host a venue, donate, or help organize.
+weight: 10
+---
+
+There are lots of ways to be part of PyLadies Vancouver, and most of them don't require
+any special access or prior experience. Pick the one that fits you:
+
+- **[Speak at our meetup](/handbook/ways-to-participate/speak/)** — share something you've
+  learned, at any experience level
+- **[Host a venue](/handbook/ways-to-participate/host/)** — offer a space for an evening
+- **[Donate and sponsor](/handbook/ways-to-participate/donate/)** — support our community
+  financially
+- **[Help organize](/handbook/ways-to-participate/help-organize/)** — lend a hand with the
+  work behind each event
+
+Not sure where you fit? Say hi in the **#city-vancouver** channel on the
+[PyLadies Slack](https://slackin.pyladies.com) and we'll help you find a spot.

--- a/content/handbook/ways-to-participate/donate.md
+++ b/content/handbook/ways-to-participate/donate.md
@@ -1,0 +1,37 @@
+---
+author: PyLadies Vancouver
+title: Donate and sponsor
+description: How to support PyLadies Vancouver and the global PyLadies community through donations and sponsorship.
+weight: 30
+toc: true
+---
+
+PyLadies Vancouver is run entirely by volunteers, and donations help us keep our meetups
+free and welcoming. There are two ways to give, depending on what you'd like to support.
+
+## Support PyLadies Vancouver
+
+Donating to PyLadies Vancouver helps cover the costs of running our meetups, workshops,
+and community events.
+
+{{< button color="primary" href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=60" >}}
+    Donate to PyLadies Vancouver
+{{< /button >}}
+
+## Support PyLadiesCon
+
+You can also support **PyLadiesCon**, the global PyLadies online conference, which serves
+the worldwide PyLadies community.
+
+{{< button color="secondary" href="https://psfmember.org/civicrm/contribute/transact/?reset=1&id=53" >}}
+    Donate to PyLadiesCon
+{{< /button >}}
+
+## Sponsor an event
+
+Beyond direct donations, you can sponsor a specific event — most commonly by **covering
+food** (like pizza) for an evening. A food sponsor doesn't need to be the venue host; it's
+a great, low-commitment way for an organization to support the local Python community.
+
+Interested in sponsoring? Email **vancouver at pyladies dot com** or reach out in the
+**#city-vancouver** channel on the [PyLadies Slack](https://slackin.pyladies.com).

--- a/content/handbook/ways-to-participate/help-organize.md
+++ b/content/handbook/ways-to-participate/help-organize.md
@@ -1,0 +1,41 @@
+---
+author: PyLadies Vancouver
+title: Help organize
+description: Ways to help organize PyLadies Vancouver events — most need no special access.
+weight: 40
+toc: true
+---
+
+Organizing our events is a team effort, and there's room for lots of hands. **Most of these
+don't need any special access or accounts** — especially blog write-ups and design work.
+
+## Ways to pitch in
+
+- **Coordinate with our venue host** — handle logistics with the space and confirm details
+- **Coordinate with sponsors** — line up food or other event sponsorship
+- **Speaker support** — help speakers prepare and feel welcome before and during the event
+- **Be the MC of the day** — host the event, introduce speakers, and keep the program on time
+- **Write blog recaps** — turn an event into a write-up for the site
+- **Design assets** — posters, social graphics, and event banners
+- **Speak or host** — see [Ways to participate](/handbook/ways-to-participate/)
+
+## How to get started
+
+Just tell us in the **#city-vancouver** channel on the
+[PyLadies Slack](https://slackin.pyladies.com) what you'd like to help with, and we'll set
+you up. No experience required.
+
+{{< button href="https://slackin.pyladies.com" >}}
+    Join the PyLadies Slack
+{{< /button >}}
+
+## Design and brand assets
+
+For design work and blog graphics, you're welcome to use our logo and brand assets:
+**[design assets — link to be added]**.
+
+## A note for organizers
+
+Whenever you reach out to venues, vendors, or speakers, **always CC
+vancouver@pyladies.com**. It keeps the whole team in the loop and means nothing depends on
+a single person's inbox.

--- a/content/handbook/ways-to-participate/host.md
+++ b/content/handbook/ways-to-participate/host.md
@@ -1,0 +1,49 @@
+---
+author: PyLadies Vancouver
+title: Host a venue
+description: What it takes to host a PyLadies Vancouver meetup, what we need, and what to expect.
+weight: 20
+toc: true
+---
+
+Venue hosts make our meetups possible. Hosting means providing a space for an evening;
+the PyLadies organizing team handles all the coordination, promotion, and running of the
+event.
+
+## What we need
+
+The bare minimum to host is:
+
+- **A space that comfortably fits our group** (typically 20–30 people)
+- **A projector or screen and basic A/V** for the talks
+
+That's it. A spot that's accessible by public transit is a big plus.
+
+## What's optional
+
+- **Food** (often pizza) is **optional** — always appreciated, but not required to host.
+  Food can also be covered by a separate sponsor, who doesn't have to be the same
+  organization providing the venue.
+- Drinks, snacks, and any extra hospitality are welcome but never expected.
+
+## What hosting involves
+
+- Letting our group into the building and pointing us to the room
+- Sharing any access, safety, or conduct rules your space requires
+- Most venues ask us to sign an **event hosting agreement** covering booking lead time,
+  setup/cleanup, access procedures, and a cancellation policy — we're happy to work within
+  these.
+
+We treat your space with care: we set up and reset the room, clean up after ourselves, and
+follow your rules. Keeping a venue welcoming for the next event is a priority for us.
+
+## How to offer a space
+
+If you have a space in Vancouver and would like to host, we'd love to hear from you:
+
+{{< button color="primary" href="mailto:vancouver@pyladies.com" >}}
+    Get in touch
+{{< /button >}}
+
+You can also reach us in the **#city-vancouver** channel on the
+[PyLadies Slack](https://slackin.pyladies.com).

--- a/content/handbook/ways-to-participate/speak.md
+++ b/content/handbook/ways-to-participate/speak.md
@@ -1,0 +1,70 @@
+---
+author: PyLadies Vancouver
+title: Speak at our meetup
+description: Who should speak, what to talk about, how to submit, and what to expect when speaking at PyLadies Vancouver.
+weight: 10
+toc: true
+---
+
+We're always looking for speakers, and we'd love to hear from you — **no experience
+necessary**. Whether it's your first time on stage or your hundredth, our meetups are a
+warm, supportive place to share what you know.
+
+## Who should speak
+
+Everyone has something worth sharing. You should consider speaking if you:
+
+- Have learned something with Python (or an adjacent tool) and can walk others through it
+- Built a project, solved a tricky problem, or discovered something you found useful
+- Want practice presenting in a friendly, low-pressure setting
+- Have never spoken before — we especially encourage first-time speakers
+
+You do **not** need to be an expert, have a novel topic, or hold a particular job title.
+If you're unsure whether your idea is a fit, ask us — the answer is almost always yes.
+
+## What to talk about
+
+Anything in or around the Python and open source world: a library or tool, a project you
+built, a concept explained simply, a career or learning story, data science, web, AI,
+testing, automation — whatever you're excited about. Beginner-friendly topics are very
+welcome.
+
+## Talk formats
+
+- **Lightning talk** — 5 minutes
+- **Standard talk** — 15–30 minutes
+- **Workshop** — up to 2 hours, hands-on
+
+## How to submit
+
+We collect talk proposals through **Sessionize**. Submit your idea here:
+
+{{< button color="primary" href="https://sessionize.com/pyladies-vancouver-meetup/" >}}
+    Submit your talk idea
+{{< /button >}}
+
+You don't need a polished abstract to start a conversation — if you'd rather talk it
+through first, reach out in the **#city-vancouver** channel on the
+[PyLadies Slack](https://slackin.pyladies.com) or email **vancouver at pyladies dot com**.
+
+## How to prepare
+
+- **Aim your talk at a friendly, mixed-experience audience** — assume curiosity, not
+  expertise.
+- **Practice your timing** so you fit your slot, leaving room for questions.
+- **Bring your slides on your own laptop** if you can; let us know your adapter needs in
+  advance.
+- **Share your slides** with us afterward — we like to link them from the event recap.
+
+## What we provide
+
+- A welcoming, engaged audience and a friendly room
+- A projector / screen and the basics for your talk
+- Support before and during the event — we'll introduce you and help you feel at ease
+- A spot in our event recap and a thank-you to you and your work
+
+## What we expect
+
+- Talks that are welcoming and inclusive of a diverse audience
+- That all speakers follow the [PyLadies Code of Conduct](https://www.pyladies.com/CodeOfConduct/)
+- A heads-up as early as possible if your plans change, so we can adjust the program

--- a/data/handbook.yml
+++ b/data/handbook.yml
@@ -1,0 +1,35 @@
+- title: Ways to participate
+  link: /handbook/ways-to-participate
+  pages:
+    - title: Speak at our meetup
+      link: speak
+    - title: Host a venue
+      link: host
+    - title: Donate and sponsor
+      link: donate
+    - title: Help organize
+      link: help-organize
+- title: Organizing a meetup
+  link: /handbook/organizing-a-meetup
+  pages:
+    - title: Where things live
+      link: where-things-live
+    - title: Pick a date and venue
+      link: date-and-venue
+    - title: Speakers and call for proposals
+      link: speakers-and-cfp
+    - title: Create the Luma event
+      link: create-luma-event
+    - title: Announce the event
+      link: announce
+    - title: On the day
+      link: on-the-day
+    - title: Wrap-up and recap
+      link: wrap-up-and-recap
+    - title: Updating the website
+      link: updating-the-website
+- title: Templates
+  link: /handbook/templates
+  pages:
+    - title: Luma event template
+      link: luma-event-template


### PR DESCRIPTION
## Summary

Adds a full **/handbook/** section — an open guide to how PyLadies Vancouver works — navigable via a left sidebar (driven by `data/handbook.yml`). It documents both how to participate and how we run events, for transparency and to onboard volunteers.

**Ways to participate** (thorough guides — who it's for, how to prepare, what we provide, expectations):
- Speak at our meetup
- Host a venue
- Donate and sponsor
- Help organize — incl. organizing roles: venue/sponsor coordination, speaker support, being the MC

**Organizing a meetup** (the behind-the-scenes runbook):
- Where things live · Pick a date and venue · Speakers and call for proposals · Create the Luma event · Announce · On the day · Wrap-up and recap · Updating the website

**Templates**: the Luma event description template

The Welcome page includes a **Stay up to date** section (Luma calendar, RSS, social, and the `#pyladiesvancouver` hashtag).

### Bundled community changes
- "Handbook" added to the top nav
- Instagram added to the site-wide social links
- Slack invite added to the About page
- Get Involved cards (Speak / Host / Donate) now link into their guides

## Notes
- The **design-assets link** in "Help organize" is a `[link to be added]` placeholder.
- Sidebar nav is data-driven (`data/handbook.yml`); titles avoid `&` because the theme's titleCase double-escapes it on list/card pages.

## Test plan
- [x] Clean build with Hugo 0.141.0 (theme-pinned), exit 0, no logged errors
- [x] Sidebar renders all groups + sub-pages, active item highlighted
- [x] Internal links validate (validate = true); RSS link uses a raw anchor
- [x] No double-escaped ampersands; titles read "and"
- [ ] Local visual check of the section + sidebar
