### PR TITLE
Center homepage body content (fix off-center Upcoming Events)

### DIFF
--- a/layouts/_default/list/body.html
+++ b/layouts/_default/list/body.html
@@ -1,0 +1,39 @@
+{{- /*
+  Project override of Hinode's _default/list/body.html (theme v0.29.3).
+  Only change vs. upstream: on the home page, render the page body in a single
+  full-width column (instead of the left col-9 + empty col-3), so centered
+  content like the Upcoming Events block is centered on the page rather than
+  offset to the left. Non-home list pages keep the original two-column layout.
+  Keep in sync with the theme template when upgrading Hinode.
+*/ -}}
+{{- $sections := $.Scratch.Get "sections" -}}
+{{- $fullCover := $.Scratch.Get "fullCover" -}}
+{{- $breakpoint := $.Scratch.Get "breakpoint" -}}
+{{- $layout := .Params.layout -}}
+{{- $title := .Title }}
+{{ if site.Params.main.titleCase }}{{ $title = title $title }}{{ end }}
+
+<div class="row row-cols-1 {{ if not .IsHome }}row-cols-{{ $breakpoint.current }}-2{{ end }}">
+    <div class="col-12{{ if not .IsHome }} col-{{ $breakpoint.current }}-9{{ end }}">
+        {{ if not .IsHome }}
+            {{ with $title }}<p id="{{ anchorize . }}" class="display-4 mt-5{{ if and $.IsHome site.Params.home.centerHeadline }} text-center{{ end }}">{{ . }}</p>{{ end }}
+        {{ end }}
+        {{ if (.Params.menu) }}
+            {{- partial "assets/section-menu.html" (dict "page" .) -}}
+        {{- end -}}
+        {{- $loading := "" -}}
+        {{- if or (eq $layout "featured") .IsHome -}}
+            {{- if $fullCover }}{{ $loading = site.Params.main.loading }}{{ end }}
+        {{ end }}
+        {{- $content := partial "utilities/ProcessContent" (dict "page" . "raw" .RawContent "loading" $loading) -}}
+        {{- $content | safeHTML -}}
+        {{ if and (and $sections (eq (len $sections) 1)) (not $content) }}
+            <p class="pt-4">{{- T "emptyList" }}.</p>
+        {{ end }}
+    </div>
+    {{ if not .IsHome }}
+    <div class="col col-{{ $breakpoint.current }}-3 d-none d-{{ $breakpoint.current }}-block">
+        {{/* Empty in default layout */}}
+    </div>
+    {{ end }}
+</div>


### PR DESCRIPTION
## Summary

The "Upcoming Events" block on the homepage appeared shifted left of center. The Hinode theme renders the home page body inside a left `col-md-9` column with an empty `col-md-3` beside it, so even a `text-center` block sits left of page-center on desktop.

This overrides `layouts/_default/list/body.html` so that **on the home page only**, the body content renders in a single full-width `col-12` column — letting the centered Upcoming Events block (and anything else in the home body) center on the page. Non-home list pages (blog, tags) keep the original two-column layout.

Follow-up to the events embed added in #6.

## Test plan
- [x] Clean build with Hugo 0.141.0 (theme-pinned), exit 0, no logged errors
- [x] Home body content renders as full-width `col-12`
- [x] Blog list page still uses `col-md-9` (unaffected)
- [ ] Local visual check that Upcoming Events is centered
