### PR TITLE
Document blog banner image dimensions in the handbook

### DIFF
--- a/content/handbook/organizing-a-meetup/updating-the-website.md
+++ b/content/handbook/organizing-a-meetup/updating-the-website.md
@@ -13,11 +13,23 @@ Changes go through a pull request and deploy automatically via Netlify once merg
 ## Blog posts
 
 Blog posts live in `content/blog/` as Markdown files with front matter (title, author,
-date, description, tags, thumbnail). Event photos go in `assets/img/`.
+date, description, tags, thumbnail). Event photos and banner images go in `assets/img/`.
+
+### Banner images
+
+A post's `thumbnail` banner is cropped to different aspect ratios in different places, so
+export it at **21:9, ideally 2800x1200 pixels** (the largest size the site renders), and
+keep the important content (text, logos, faces) **centered** so nothing gets cut off:
+
+- **Post header:** cropped to 21:9 (ultra-wide)
+- **Homepage blog card:** cropped to 16:9
+- **Social sharing preview:** cropped to 2:1
+
+A 21:9 image with centered content looks good in all three.
 
 ## Building locally
 
-Build locally with the Hugo version the theme is pinned to — the newer Homebrew Hugo can
+Build locally with the Hugo version the theme is pinned to: the newer Homebrew Hugo can
 break the Hinode theme. Run the local dev server, check your changes, then open a pull
 request.
 
@@ -25,4 +37,4 @@ request.
 
 Upcoming events are pulled live from our Luma calendar, which is embedded on the
 [Events page](/events/) and the homepage. Once an event is published on Luma it appears on
-the site automatically — no code change needed per event.
+the site automatically, with no code change needed per event.


### PR DESCRIPTION
## Summary

Adds banner-image guidance to the handbook's **Updating the website** guide, so contributors know what size to export blog post banners.

Because the theme crops a post's `thumbnail` to different ratios in different places, the guide now recommends exporting at **21:9 (ideally 2800x1200)** with key content centered:
- Post header → 21:9
- Homepage blog card → 16:9
- Social sharing preview → 2:1

Also removes two em dashes from the page.

## Test plan
- [x] Clean build with Hugo 0.141.0, exit 0, no errors